### PR TITLE
Set controller manually

### DIFF
--- a/Komunikator_Klient/src/main/java/com/example/komunikator_klient/Controler_login.java
+++ b/Komunikator_Klient/src/main/java/com/example/komunikator_klient/Controler_login.java
@@ -65,16 +65,16 @@ public class Controler_login {
         if (logic.validNick()) {
 
             usednickErroor.setText("");
-            Parent root = FXMLLoader.load(getClass().getResource("main-view.fxml"));
+            FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("main-view.fxml"));
+            fxmlLoader.setController(this);
 
+            Parent root = fxmlLoader.load();
             Stage window = (Stage) connectButton.getScene().getWindow();
             window.setScene(new Scene(root, 600, 400));
 
-
-
+            sendButton.setOnAction(actionEvent -> sendMessage());
 
             logic.listenForMessage(messageList);
-
 
         } else {
             usednickErroor.setText("Your nick is already used");

--- a/Komunikator_Klient/src/main/resources/com/example/komunikator_klient/main-view.fxml
+++ b/Komunikator_Klient/src/main/resources/com/example/komunikator_klient/main-view.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.layout.HBox?>
-<AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.example.komunikator_klient.Controler_login">
+<AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <ScrollPane fx:id="scrolPane" layoutX="45.0" layoutY="51.0" prefHeight="198.0" prefWidth="513.0">
         <content>
@@ -18,6 +18,6 @@
         </content>
       </ScrollPane>
       <TextField fx:id="sendFiel" layoutX="45.0" layoutY="265.0" prefHeight="32.0" prefWidth="453.0" />
-      <Button fx:id="sendButton" layoutX="507.0" layoutY="268.0" mnemonicParsing="false" onAction="#sendMessage" text="Send" />
+      <Button fx:id="sendButton" layoutX="507.0" layoutY="268.0" mnemonicParsing="false" text="Send" />
    </children>
 </AnchorPane>


### PR DESCRIPTION
Problem jest spowodowany przez to, że po kliknięciu w guzik `Connect` ma miejsce zaladowanie nowego drzewa komponentów i ustawienie nowej sceny - natomiast pola klasy z adnotacją `@FXML` nadal wskazują na kontrolki z widoku `login-view.fxml` i nie zostają odświeżone (na widoku `login-view.fxml` nie ma kontrolki `messagesList`).

Aby wszystko zadziałało w obecnych warunkach, po załadowaniu `main-view.fxml` należy ręcznie przypisać `this` jako kontroler. Niestety trzeba liczyć się z tym, że po tym manewrze pola zmapowane poprzednio z kontrolkami w `login-view.fxml` w tym momencie przyją wartość `null`.

Możemy przegadać architekturę aplikacji - zdecydowanie łatwiej byłoby wyłonić dwa oddzielne widoki i spiąć je w kupę.